### PR TITLE
fix const pointer lost its namespace

### DIFF
--- a/swig/Package.i
+++ b/swig/Package.i
@@ -2,3 +2,6 @@
 
 %include <zypp/Package.h>
 
+typedef ::zypp::intrusive_ptr<const Package> Package_constPtr;
+%template(Package_constPtr)        ::zypp::intrusive_ptr<const Package>;
+

--- a/swig/Patch.i
+++ b/swig/Patch.i
@@ -3,3 +3,4 @@
 %ignore zypp::Patch::id;
 
 %include <zypp/Patch.h>
+

--- a/swig/Pattern.i
+++ b/swig/Pattern.i
@@ -1,1 +1,5 @@
 %include <zypp/Pattern.h>
+
+typedef ::zypp::intrusive_ptr<const Pattern> Pattern_constPtr;
+%template(Pattern_constPtr)        ::zypp::intrusive_ptr<const Pattern>;
+

--- a/swig/Product.i
+++ b/swig/Product.i
@@ -1,2 +1,6 @@
 %ignore zypp::Product::type;
 %include <zypp/Product.h>
+
+typedef ::zypp::intrusive_ptr<const Product> Product_constPtr;
+%template(Product_constPtr)        ::zypp::intrusive_ptr<const Product>;
+

--- a/swig/SrcPackage.i
+++ b/swig/SrcPackage.i
@@ -1,1 +1,5 @@
 %include <zypp/SrcPackage.h>;
+
+typedef ::zypp::intrusive_ptr<const SrcPackage> SrcPackage_constPtr;
+%template(SrcPackage_constPtr)        ::zypp::intrusive_ptr<const SrcPackage>;
+


### PR DESCRIPTION
try to build python-zypp with swig 2.0.7 or newer,
the *_constPtr always lost its namespace

Signed-off-by: Gui Chen gui.chen@intel.com
