### PR TITLE
Enforce Python 2.7

### DIFF
--- a/libzypp-bindings.spec.cmake
+++ b/libzypp-bindings.spec.cmake
@@ -27,7 +27,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  cmake
 BuildRequires:  gcc-c++ >= 4.5
 BuildRequires:  libzypp-devel >= 14.30.0
-BuildRequires:  python-devel
+BuildRequires:  python-devel < 3
 BuildRequires:  ruby-devel
 BuildRequires:  swig >= 1.3.40
 Source:         %{name}-%{version}.tar.bz2

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -12,6 +12,9 @@ SET( SWIG_INPUT "${CMAKE_CURRENT_SOURCE_DIR}/zypp.i" )
 #
 
 FIND_PACKAGE(Ruby)
+# Enforce Python 2.7, libzypp-bindings does not yet work with Python3
+set(PythonLibs_FIND_VERSION 2.7)
+set(PythonLibs_FIND_VERSION_MAJOR 2)
 FIND_PACKAGE(PythonLibs)
 FIND_PACKAGE(Perl)
 


### PR DESCRIPTION
libzypp-bindings is not yet ready for Python 3. This patch enforces
Python 2.7.

Closes issue #8
