### PR TITLE
zypp::Capabilities: Add CapNames() function

### DIFF
--- a/swig/Capabilities.i
+++ b/swig/Capabilities.i
@@ -8,3 +8,21 @@ by_value_iterator(zypp::Capabilities);
 #ifdef SWIGPERL5
 forwarditer(zypp::Capabilities, zypp::Capability);
 #endif
+
+#ifdef SWIGPYTHON
+%include "std_vector.i"
+%include "std_string.i"
+
+%template(StringVector) std::vector<std::string>;
+
+%extend  zypp::Capabilities {
+    std::vector<std::string> CapNames()
+    {
+        std::vector<std::string> caps;
+        for (zypp::Capabilities::const_iterator it = self->begin(); it != self->end(); ++it) {
+            caps.push_back((*it).asString());
+        }
+        return caps;
+    }
+}
+#endif


### PR DESCRIPTION
Split off of #11: Now uses `std::vector<std::string>` for returning a list of strings. This has now been tested:

```
>>> import zypp
>>> cap = zypp.Capabilities()
>>> for capability in cap.CapNames():
...     print capability
...
```