### PR TITLE
allow any python version

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -12,7 +12,7 @@ SET( SWIG_INPUT "${CMAKE_CURRENT_SOURCE_DIR}/zypp.i" )
 #
 
 OPTION(BUILD_RUBY_BINDINGS "Build Ruby bindings" ON)
-OPTION(BUILD_PYTHON2_BINDINGS "Build Python 2 bindings" ON)
+OPTION(BUILD_PYTHON_BINDINGS "Build Python bindings" ON)
 OPTION(BUILD_PERL5_BINDINGS "Build Perl 5 bindings" ON)
 
 #
@@ -26,10 +26,7 @@ IF(BUILD_RUBY_BINDINGS)
   ENDIF()
 ENDIF()
 
-IF(BUILD_PYTHON2_BINDINGS)
-  # Enforce Python 2.7, libzypp-bindings does not yet work with Python3
-  set(PythonLibs_FIND_VERSION 2.7)
-  set(PythonLibs_FIND_VERSION_MAJOR 2)
+IF(BUILD_PYTHON_BINDINGS)
   FIND_PACKAGE(PythonLibs)
   IF(PYTHON_LIBRARY)
     ADD_SUBDIRECTORY(python)


### PR DESCRIPTION
seems some tests are ok on 2.7 as well as on 3.4, so enable it:

```
-- Found SWIG: /usr/bin/swig (found version "3.0.6") 
-- ZYpp path not set. Looking for it.
-- ZYpp found: includes in /usr/include, library in /usr/lib64/libzypp.so
-- Zypp so library version 1505
-- Found PythonLibs: /usr/lib64/libpython3.4m.so (found version "3.4.3") 
-- Found PythonInterp: /usr/bin/python3.4 (found version "3.4.3") 
-- Python executable:   /usr/bin/python3.4
-- Python include path: /usr/include/python3.4m
-- Python site dir:     /usr/lib/python3.4/site-packages
-- Configuring done

```

```
/usr/bin/cmake -P cmake_install.cmake
-- Install configuration: "Release"
-- Installing: /home/xantares/projects/aur-scripts/python2-zypp/pkg/python2-zypp/usr/lib/python3.4/site-packages/_zypp.so
-- Installing: /home/xantares/projects/aur-scripts/python2-zypp/pkg/python2-zypp/usr/lib/python3.4/site-packages/zypp.py

```

```
$ PYTHONPATH=/home/xantares/projects/aur-scripts/python2-zypp/pkg/python2-zypp/usr/lib/python3.4/site-packages ctest 
Test project /home/xantares/projects/aur-scripts/python2-zypp/src/libzypp-bindings
    Start 1: bindings_python_loading
1/3 Test #1: bindings_python_loading ............   Passed    0.20 sec
    Start 2: bindings_python_repoinfo
2/3 Test #2: bindings_python_repoinfo ...........   Passed    0.10 sec
    Start 3: bindings_python_commit_callbacks
3/3 Test #3: bindings_python_commit_callbacks ...***Failed    0.02 sec

67% tests passed, 1 tests failed out of 3

Total Test time (real) =   0.32 sec

The following tests FAILED:
          3 - bindings_python_commit_callbacks (Failed)
```
